### PR TITLE
fix: bot name typo

### DIFF
--- a/src/bot/constants.ts
+++ b/src/bot/constants.ts
@@ -1,3 +1,3 @@
-export const BOT_USERNAME = 'HackerRack Bot';
+export const BOT_USERNAME = 'HackerRank Bot';
 export const BOT_ICON_URL =
   'https://avatars.slack-edge.com/2020-01-09/888294288899_3b3b0325f633851e130c_192.png';


### PR DESCRIPTION
Just noticed this in Slack. Do we need need to update this title in Slack as well?