### PR TITLE
feat: use REQUEST_EXPIRATION_MIN environment variable for expiration length timeout

### DIFF
--- a/src/bot/constants.ts
+++ b/src/bot/constants.ts
@@ -1,1 +1,0 @@
-export const REQUEST_WINDOW_LENGTH_HOURS = 2;

--- a/src/bot/joinQueue.ts
+++ b/src/bot/joinQueue.ts
@@ -5,7 +5,6 @@ import { App, Option, View } from '@slack/bolt';
 import { blockUtils } from '@utils/blocks';
 import log from '@utils/log';
 import { bold, codeBlock, compose } from '@utils/text';
-import { REQUEST_WINDOW_LENGTH_HOURS } from './constants';
 import { ActionId, Interaction } from './enums';
 import { chatService } from '@/services/ChatService';
 
@@ -98,7 +97,9 @@ export const joinQueue = {
         text = compose(
           `You've been added to the queue for: ${bold(
             languages.join(', '),
-          )}. When it's your turn, we'll send you a DM just like this and you'll have ${REQUEST_WINDOW_LENGTH_HOURS} hours to respond before we move to the next person.`,
+          )}. When it's your turn, we'll send you a DM just like this and you'll have ${
+            process.env.REQUEST_EXPIRATION_MIN
+          } minutes to respond before we move to the next person.`,
           'You can opt out by using the "Leave Queue" shortcut next to the one you just used!',
         );
       } else {

--- a/src/bot/requestReview.ts
+++ b/src/bot/requestReview.ts
@@ -7,11 +7,10 @@ import { App, PlainTextOption, View } from '@slack/bolt';
 import { blockUtils } from '@utils/blocks';
 import log from '@utils/log';
 import { bold, codeBlock, compose, mention, ul } from '@utils/text';
-import Time from '@utils/time';
 import { PendingReviewer } from '@models/ActiveReview';
 import { ActionId, Deadline, DeadlineLabel, Interaction } from './enums';
 import { chatService } from '@/services/ChatService';
-import { REQUEST_WINDOW_LENGTH_HOURS } from '@bot/constants';
+import Time from '@utils/time';
 
 export const requestReview = {
   app: undefined as unknown as App,
@@ -185,7 +184,7 @@ export const requestReview = {
       );
       const pendingReviewer: PendingReviewer = {
         userId: reviewer.id,
-        expiresAt: Date.now() + Time.HOUR * REQUEST_WINDOW_LENGTH_HOURS,
+        expiresAt: Date.now() + Number(process.env.REQUEST_EXPIRATION_MIN) * Time.MINUTE,
         messageTimestamp: messageTimestamp,
       };
       pendingReviewers.push(pendingReviewer);

--- a/src/services/QueueService.ts
+++ b/src/services/QueueService.ts
@@ -5,8 +5,6 @@ import log from '@/utils/log';
 import Time from '@/utils/time';
 import { User } from '@models/User';
 
-const REQUEST_EXPIRATION_MIN = Number(process.env.REQUEST_EXPIRATION_MIN) * Time.MINUTE;
-
 export async function getInitialUsersForReview(
   languages: string[],
   numberOfReviewers: number,
@@ -50,7 +48,7 @@ export async function nextInLine(
   }
   const next = {
     userId: nextUser.id,
-    expiresAt: Date.now() + REQUEST_EXPIRATION_MIN,
+    expiresAt: Date.now() + Number(process.env.REQUEST_EXPIRATION_MIN) * Time.MINUTE,
   };
   log.d(
     'nextInLine',
@@ -58,8 +56,7 @@ export async function nextInLine(
     JSON.stringify({
       next,
       now: Date.now(),
-      REQUEST_EXPIRATION_MIN,
-      env: process.env.REQUEST_EXPIRATION_MIN,
+      env: Number(process.env.REQUEST_EXPIRATION_MIN) * Time.MINUTE,
       min: Time.MINUTE,
     }),
   );


### PR DESCRIPTION
Previously, this was used in one spot but this change uses the same value in all
scenarios where we request a review so we're consistent.