### PR TITLE
feat: use less-strict language matching for potential reviewers

### DIFF
--- a/src/services/QueueService.ts
+++ b/src/services/QueueService.ts
@@ -1,6 +1,6 @@
 import { ActiveReview, PartialPendingReviewer } from '@/database/models/ActiveReview';
 import { userRepo } from '@/database/repos/userRepo';
-import { containsAll } from '@/utils/array';
+import { containsMatches } from '@/utils/array';
 import log from '@/utils/log';
 import Time from '@/utils/time';
 import { User } from '@models/User';
@@ -20,12 +20,23 @@ function sortAndFilterUsers(
   excludedUserIds: Set<string> = new Set(),
 ): User[] {
   const allowedUsers = users.filter(({ id }) => !excludedUserIds.has(id));
-  const usersByLanguage = allowedUsers.filter(user => containsAll(user.languages, languages));
 
-  return usersByLanguage.sort(sortUsersCallback);
+  // Try to find a user with all the matching languages first.
+  // If no matches, go to one less match, and then another less until we run out of matches to try.
+  let usersByLanguage: User[] = [];
+  for (let numberOfMatches = languages.length; numberOfMatches > 0; numberOfMatches--) {
+    usersByLanguage = allowedUsers.filter(user =>
+      containsMatches(user.languages, languages, numberOfMatches),
+    );
+    if (usersByLanguage.length > 0) {
+      break;
+    }
+  }
+
+  return usersByLanguage.sort(byLastReviewedDate);
 }
 
-export function sortUsersCallback(l: User, r: User): number {
+export function byLastReviewedDate(l: User, r: User): number {
   if (l.lastReviewedDate == null) return -1;
   if (r.lastReviewedDate == null) return 1;
   return l.lastReviewedDate - r.lastReviewedDate;

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -1,3 +1,13 @@
-export function containsAll<T>(arrayToCheck: T[], valuesIncluded: T[]): boolean {
-  return valuesIncluded.every(expectedValue => arrayToCheck.indexOf(expectedValue) !== -1);
+/**
+ * Returns true if there are the provided number of matches between the two provided arrays.
+ */
+export function containsMatches<T>(
+  arrayToCheck: T[],
+  valuesIncluded: T[],
+  numberOfMatches: number,
+): boolean {
+  return (
+    valuesIncluded.filter(expectedValue => arrayToCheck.includes(expectedValue)).length ==
+    numberOfMatches
+  );
 }


### PR DESCRIPTION
Prior to this change we could only match if the user's selected languages
contained all of the languages on the review. Now, if no users are found
that match all of the languages we'll gradually decrease the amount of
matches required to try and find someone who can look at the review.

closes #79