### PR TITLE
chore: change usage of ts-jest in a few places

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,4 @@
-const { pathsToModuleNameMapper } = require('ts-jest/utils');
+const { pathsToModuleNameMapper } = require('ts-jest');
 const { compilerOptions } = require('./tsconfig');
 
 module.exports = {

--- a/src/cron/__tests__/reviewProcessor.test.ts
+++ b/src/cron/__tests__/reviewProcessor.test.ts
@@ -3,11 +3,10 @@ import { ActiveReview, PendingReviewer } from '@/database/models/ActiveReview';
 import { activeReviewRepo } from '@/database/repos/activeReviewsRepo';
 import { RequestService } from '@/services';
 import { App } from '@slack/bolt';
-import { mocked } from 'ts-jest/utils';
 import { reviewProcessor } from '../reviewProcessor';
 
 Date.now = jest.fn();
-const nowMock = mocked(Date.now);
+const nowMock = jest.mocked(Date.now);
 nowMock.mockReturnValue(1000000);
 
 function mockReview(pendingReviewers: PendingReviewer[]): ActiveReview {


### PR DESCRIPTION
Upcoming release of `ts-jest` will remove the `mocked` method.