### PR TITLE
feat: add cron job to remove users who are no longer active

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ You don't have to commit anything before doing a deploy. Just make a change and 
 
 This repo uses [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.2/). Here are the types of commits we use:
 
-- [`feat: ...`](https://github.com/apklinker/hacker-rank-queue/commit/2d3e71b83b51ce9a4054098ad5d6dc665182e885) - Used when the commit introduces a new feature
-- [`fix: ...`](https://github.com/apklinker/hacker-rank-queue/commit/439e8c6fd43255546b30aaab96e121dec271c9b7) - Fixing a bug in user facing code
-- [`chore: ...`](https://github.com/apklinker/hacker-rank-queue/commit/e67d655eab0a546b58ae883b77d0bd755c9dff0f) - Refactor, fixing lint or test errors, formatting, etc
+- [`feat: ...`](https://github.com/sourceallies/hacker-rank-queue/commit/2d3e71b83b51ce9a4054098ad5d6dc665182e885) - Used when the commit introduces a new feature
+- [`fix: ...`](https://github.com/sourceallies/hacker-rank-queue/commit/439e8c6fd43255546b30aaab96e121dec271c9b7) - Fixing a bug in user facing code
+- [`chore: ...`](https://github.com/sourceallies/hacker-rank-queue/commit/e67d655eab0a546b58ae883b77d0bd755c9dff0f) - Refactor, fixing lint or test errors, formatting, etc
 - `ci: ...` - When you update the CI _(no example)_
-- [`docs: ...`](https://github.com/apklinker/hacker-rank-queue/commit/2d30931196b014996f8a52267a4bfd1fa850d167) - When you update the `README.md` or other documentation
+- [`docs: ...`](https://github.com/sourceallies/hacker-rank-queue/commit/2d30931196b014996f8a52267a4bfd1fa850d167) - When you update the `README.md` or other documentation
 - `BREAKING CHANGE: ...` - When there's a feature that leads to a completely different flow for users _(no example)_
 
 On feature branches, don't worry about doing conventional commits. Instead, just name the PR According to the patterns above, and scope it to just that one thing. When you squash and merge (the only allowed way to merge), the commit message will default to a conventional commit. Fill out a description if you want, but leave the title of the commit untouched.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.0",
   "description": "Slack bot for managing a queue of reviewers for HackerRanks",
   "main": "index.js",
-  "repository": "https://github.com/apklinker/hacker-rank-queue",
+  "repository": "https://github.com/sourceallies/hacker-rank-queue",
   "author": "Source Allies",
   "license": "MIT",
   "private": true,

--- a/src/cron/__tests__/checkAllUsersActive.test.ts
+++ b/src/cron/__tests__/checkAllUsersActive.test.ts
@@ -1,0 +1,35 @@
+import { buildMockApp } from '@utils/slackMocks';
+import { checkAllUsersActive } from '@cron/checkAllUsersActive';
+import { userRepo } from '@repos/userRepo';
+import { userService } from '@/services/UserService';
+
+describe('checkAllUsersActive', () => {
+  it('should not expire any users if they are all active', async () => {
+    const app = buildMockApp();
+    userRepo.listAll = jest.fn().mockResolvedValue([
+      { id: 'A', name: 'a', languages: [], lastReviewedDate: 1 },
+      { id: 'B', name: 'b', languages: [], lastReviewedDate: 2 },
+    ]);
+    userRepo.remove = jest.fn();
+    userService.isActive = jest.fn().mockResolvedValue(true);
+
+    await checkAllUsersActive(app);
+
+    expect(userRepo.remove).not.toHaveBeenCalled();
+  });
+
+  it('should expire a user that is no longer active', async () => {
+    const app = buildMockApp();
+    userRepo.listAll = jest.fn().mockResolvedValue([
+      { id: 'A', name: 'a', languages: [], lastReviewedDate: 1 },
+      { id: 'B', name: 'b', languages: [], lastReviewedDate: 2 },
+    ]);
+    userRepo.remove = jest.fn();
+    userService.isActive = jest.fn().mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+
+    await checkAllUsersActive(app);
+
+    expect(userRepo.remove).toHaveBeenCalledTimes(1);
+    expect(userRepo.remove).toHaveBeenCalledWith('B');
+  });
+});

--- a/src/cron/checkAllUsersActive.ts
+++ b/src/cron/checkAllUsersActive.ts
@@ -1,0 +1,42 @@
+import { App } from '@slack/bolt';
+import { userRepo } from '@repos/userRepo';
+import { userService } from '@/services/UserService';
+import log from '@utils/log';
+import { chatService } from '@/services/ChatService';
+import { codeBlock, compose } from '@utils/text';
+
+/**
+ * Scheduled job to verify all users on the user sheet are active.
+ * Removes any users that have been deactivated.
+ */
+export async function checkAllUsersActive(app: App): Promise<void> {
+  log.d('cron.checkAllUsersActive', 'Checking if all users are still active');
+
+  try {
+    const allUsers = await userRepo.listAll();
+
+    let allActive = true;
+    for (const user of allUsers) {
+      const active = await userService.isActive(app.client, user.id);
+      if (!active) {
+        allActive = false;
+        log.d(
+          'cron.checkAllUsersActive',
+          `Removing deactivated user (${user.name}) from user sheet.`,
+        );
+        await userRepo.remove(user.id);
+      }
+    }
+    if (allActive) {
+      log.d('cron.checkAllUsersActive', '✔ All users are still active');
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } catch (err: any) {
+    log.e('cron.checkAllUsersActive', 'Error determining if users are all active', err.message);
+    await chatService.postTextMessage(
+      app.client,
+      process.env.ERRORS_CHANNEL_ID,
+      compose('Nightly check on active users failed:', codeBlock(err.message)),
+    );
+  }
+}

--- a/src/cron/index.ts
+++ b/src/cron/index.ts
@@ -3,6 +3,7 @@ import { App } from '@slack/bolt';
 import log from '@utils/log';
 import { schedule } from 'node-cron';
 import { expireRequests } from './expireRequests';
+import { checkAllUsersActive } from '@cron/checkAllUsersActive';
 
 type ScheduledJob = [string, (app: App) => void | Promise<void>];
 
@@ -36,6 +37,8 @@ function getJobs(): ScheduledJob[] {
   return [
     // Midnight every day
     ['0 0 * * *', healthCheck],
+    // 12:05 AM every day
+    ['5 0 * * *', checkAllUsersActive],
     [everyFifteenWorkDay, expireRequests],
   ];
 }

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -1,0 +1,10 @@
+import { WebClient } from '@/slackTypes';
+
+export const userService = {
+  async isActive(client: WebClient, userId: string) {
+    const response = await client.users.info({
+      user: userId,
+    });
+    return !response.user?.deleted;
+  },
+};

--- a/src/services/__tests__/UserService.test.ts
+++ b/src/services/__tests__/UserService.test.ts
@@ -1,0 +1,27 @@
+import { userService } from '@/services/UserService';
+import { buildMockWebClient } from '@utils/slackMocks';
+
+describe('UserService', () => {
+  describe('isActive', () => {
+    it('should return false if the user deleted flag is true', async () => {
+      const client = buildMockWebClient();
+      client.users.info = jest.fn().mockResolvedValue({ user: { deleted: true } });
+      const isActive = await userService.isActive(client, 'ABC123');
+      expect(isActive).toBeFalsy();
+    });
+
+    it('should return true if the user deleted flag is false', async () => {
+      const client = buildMockWebClient();
+      client.users.info = jest.fn().mockResolvedValue({ user: { deleted: false } });
+      const isActive = await userService.isActive(client, 'ABC123');
+      expect(isActive).toBeTruthy();
+    });
+
+    it('should return true if the user deleted flag does not exist', async () => {
+      const client = buildMockWebClient();
+      client.users.info = jest.fn().mockResolvedValue({ user: {} });
+      const isActive = await userService.isActive(client, 'ABC123');
+      expect(isActive).toBeTruthy();
+    });
+  });
+});

--- a/src/utils/slackMocks.ts
+++ b/src/utils/slackMocks.ts
@@ -100,6 +100,9 @@ export const buildMockWebClient = (): WebClient =>
     conversations: {
       open: jest.fn(),
     },
+    users: {
+      info: jest.fn(),
+    },
   } as any);
 export const buildMockApp = (): App =>
   ({


### PR DESCRIPTION
This adds a cron job that runs every night to look through users
who are no longer active and removes them from the users sheet.

closes #64