### PR TITLE
feat: randomize sorting of users when multiple have no last reviewed date

### DIFF
--- a/src/services/QueueService.ts
+++ b/src/services/QueueService.ts
@@ -11,25 +11,7 @@ export async function getInitialUsersForReview(
   numberOfReviewers: number,
 ): Promise<User[]> {
   const allUsers = await userRepo.listAll();
-  let matches: User[] = [];
-  let numberOfReviewersStillNeeded = numberOfReviewers;
-  // loop through and call to retrieve users until our desired amount of reviewers is
-  // found, or we can't find enough that match our criteria.
-  while (numberOfReviewersStillNeeded > 0) {
-    const matchesWithFewerLanguages = sortAndFilterUsers(
-      allUsers,
-      languages,
-      new Set(matches.map(user => user.id)),
-    ).slice(0, numberOfReviewersStillNeeded);
-    matches = matches.concat(matchesWithFewerLanguages);
-    numberOfReviewersStillNeeded = numberOfReviewers - matches.length;
-
-    // break out of loop if we can't find any more users that match the criteria
-    if (matchesWithFewerLanguages.length == 0) {
-      break;
-    }
-  }
-  return matches;
+  return sortAndFilterUsers(allUsers, languages).slice(0, numberOfReviewers);
 }
 
 function sortAndFilterUsers(
@@ -46,9 +28,15 @@ function sortAndFilterUsers(
 }
 
 export function byLastReviewedDate(l: User, r: User): number {
-  if (l.lastReviewedDate == null) return -1;
-  if (r.lastReviewedDate == null) return 1;
-  return l.lastReviewedDate - r.lastReviewedDate;
+  if (l.lastReviewedDate == null && r.lastReviewedDate == null) {
+    return 0.5 - Math.random();
+  } else if (l.lastReviewedDate == null) {
+    return -1;
+  } else if (r.lastReviewedDate == null) {
+    return 1;
+  } else {
+    return l.lastReviewedDate - r.lastReviewedDate;
+  }
 }
 
 export async function nextInLine(

--- a/src/services/__tests__/QueueService.test.ts
+++ b/src/services/__tests__/QueueService.test.ts
@@ -36,6 +36,25 @@ describe('Queue Service', () => {
 
       expect(actualUsers).toEqual(expectedUsers);
     });
+
+    it('should randomly pick users if multiple do not have a lastReviewedAt date', () => {
+      const user1: User = makeUser(null);
+      const user2: User = makeUser(null);
+      const user3: User = makeUser(Time.DAY);
+
+      const inputUsers: User[] = [user2, user1, user3];
+
+      const actualUsers = inputUsers.sort(byLastReviewedDate);
+
+      expect(actualUsers).toHaveLength(3);
+
+      const usersWithoutLastReview = [actualUsers[0], actualUsers[1]];
+      expect(usersWithoutLastReview).toHaveLength(2);
+      expect(usersWithoutLastReview).toContainEqual(user1);
+      expect(usersWithoutLastReview).toContainEqual(user2);
+
+      expect(actualUsers[2]).toEqual(user3);
+    });
   });
 
   describe('getInitialUsersForReview', () => {


### PR DESCRIPTION
Prior to this change any new users that were added to the queue took
priority over users who have been in the queue a while but hadn't accepted
a review yet. This should help randomize the users that haven't accepted
yet to better spread out the distribution of requests.