### PR TITLE
chore: unblock `node-cron` from renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,10 +11,6 @@
     {
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "automerge": true
-    },
-    {
-      "matchPackageNames": ["node-cron"],
-      "allowedVersions": ">3.0.1"
     }
   ],
   "schedule": [


### PR DESCRIPTION
`v3.0.2` has been released so should be free to upgrade