### PR TITLE
fix: close modal after leaving queue

### DIFF
--- a/src/bot/__tests__/joinQueue.test.ts
+++ b/src/bot/__tests__/joinQueue.test.ts
@@ -268,10 +268,14 @@ describe('joinQueue', () => {
   });
 
   describe('handleLeaveQueue action', () => {
-    it('should remove user from queue and confirm via DM', async () => {
+    it('should remove user from queue, close the modal, and confirm via DM', async () => {
       const userId = 'user-to-leave';
       const actionParam = buildMockActionParam();
-      actionParam.body = { user: { id: userId }, actions: [{ action_id: 'leave-queue' }] } as any;
+      actionParam.body = {
+        user: { id: userId },
+        actions: [{ action_id: 'leave-queue' }],
+        view: { id: 'view-123' },
+      } as any;
       actionParam.client.conversations.open = jest
         .fn()
         .mockResolvedValue({ channel: { id: 'DM-123' } });
@@ -281,8 +285,8 @@ describe('joinQueue', () => {
 
       expect(actionParam.ack).toHaveBeenCalled();
       expect(userRepo.remove).toHaveBeenCalledWith(userId);
-      expect(actionParam.client.chat.postMessage).toHaveBeenCalledWith(
-        expect.objectContaining({ text: expect.stringContaining("You've been removed") }),
+      expect(actionParam.client.views.update).toHaveBeenCalledWith(
+        expect.objectContaining({ view_id: 'view-123' }),
       );
     });
 

--- a/src/bot/joinQueue.ts
+++ b/src/bot/joinQueue.ts
@@ -212,11 +212,23 @@ export const joinQueue = {
     log.d('joinQueue.handleLeaveQueue', `Removing user ${userId} from queue`);
     try {
       await userRepo.remove(userId);
-      await chatService.sendDirectMessage(
-        client,
-        userId,
-        "You've been removed from the interview queue. Use the 'Interview Queue Preferences' shortcut to rejoin.",
-      );
+      await client.views.update({
+        view_id: body.view!.id,
+        view: {
+          type: 'modal',
+          title: { type: 'plain_text', text: 'Queue Preferences' },
+          close: { type: 'plain_text', text: 'Close' },
+          blocks: [
+            {
+              type: 'section',
+              text: {
+                type: 'mrkdwn',
+                text: "You've been removed from the interview queue. Use the 'Interview Queue Preferences' shortcut to rejoin.",
+              },
+            },
+          ],
+        },
+      });
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (err: any) {
       log.e('joinQueue.handleLeaveQueue', 'Failed to remove user', err);


### PR DESCRIPTION
## Summary
- After clicking "Leave Queue" and confirming, the modal now updates to show a confirmation message with a close button instead of staying open
- Removed the redundant DM notification since the modal already shows the confirmation

## Test Plan
- [ ] Open queue preferences via the shortcut
- [ ] Click "Leave Queue" and confirm
- [ ] Modal should update to show confirmation message
- [ ] No DM should be sent