### PR TITLE
fix: exclude pairing-only users from HackerRank review queue

### DIFF
--- a/src/services/QueueService.ts
+++ b/src/services/QueueService.ts
@@ -6,6 +6,7 @@ import Time from '@/utils/time';
 import { User } from '@models/User';
 import { determineExpirationTime } from '@utils/reviewExpirationUtils';
 import { containsAny } from '@utils/array';
+import { InterviewType } from '@bot/enums';
 
 export async function getInitialUsersForReview(
   languages: string[],
@@ -23,7 +24,10 @@ export function sortAndFilterUsers(
   excludedUserIds: Set<string> = new Set(),
 ): User[] {
   const allowedUsers = users.filter(({ id }) => !excludedUserIds.has(id));
-  const usersWithAMatchingLanguage = allowedUsers.filter(user =>
+  const usersWithHackerRank = allowedUsers.filter(user =>
+    user.interviewTypes.includes(InterviewType.HACKERRANK),
+  );
+  const usersWithAMatchingLanguage = usersWithHackerRank.filter(user =>
     containsAny(user.languages, languages),
   );
 

--- a/src/services/__tests__/PositionInQueueService.test.ts
+++ b/src/services/__tests__/PositionInQueueService.test.ts
@@ -8,7 +8,7 @@ describe('PositionInQueueService', () => {
       languages: ['Java', 'C#'],
       lastReviewedDate: 1,
       lastPairingReviewedDate: undefined,
-      interviewTypes: [] as any,
+      interviewTypes: ['hackerrank'] as any,
       formats: [] as any,
     };
     const user2 = {
@@ -17,7 +17,7 @@ describe('PositionInQueueService', () => {
       languages: ['Java', 'JavaScript'],
       lastReviewedDate: 2,
       lastPairingReviewedDate: undefined,
-      interviewTypes: [] as any,
+      interviewTypes: ['hackerrank'] as any,
       formats: [] as any,
     };
     const user3 = {
@@ -26,7 +26,7 @@ describe('PositionInQueueService', () => {
       languages: ['Java', 'C#', 'JavaScript'],
       lastReviewedDate: 3,
       lastPairingReviewedDate: undefined,
-      interviewTypes: [] as any,
+      interviewTypes: ['hackerrank'] as any,
       formats: [] as any,
     };
 

--- a/src/services/__tests__/QueueService.test.ts
+++ b/src/services/__tests__/QueueService.test.ts
@@ -159,6 +159,26 @@ describe('Queue Service', () => {
       expect(actualUsers).toEqual([]);
     });
 
+    it('should not include users who do not have hackerrank in their interviewTypes', async () => {
+      const pairingOnlyUser: User = {
+        id: 'pairing-only',
+        name: 'Pairing Only User',
+        languages: ['Java', 'C#'],
+        lastReviewedDate: 0,
+        lastPairingReviewedDate: undefined,
+        interviewTypes: ['pairing'] as any,
+        formats: ['remote'] as any,
+      };
+      const users: User[] = [pairingOnlyUser, user1, user2];
+      userRepo.listAll = jest.fn().mockResolvedValueOnce(users);
+
+      const actualUsers = await getInitialUsersForReview(['Java'], 5);
+
+      expect(actualUsers).not.toContainEqual(pairingOnlyUser);
+      expect(actualUsers).toContainEqual(user1);
+      expect(actualUsers).toContainEqual(user2);
+    });
+
     it('should not include any users that are pending on other active reviews', async () => {
       const activeReviews: ActiveReview[] = [
         {


### PR DESCRIPTION
## Summary

- Users who opted into only pairing sessions were still receiving HackerRank review request DMs
- `sortAndFilterUsers` in `QueueService` now filters to only users with `InterviewType.HACKERRANK` before matching by language
- Updated `PositionInQueueService` test fixtures to reflect that queue position is for HackerRank reviewers

## Test plan

- [ ] Verify a user with only `pairing` in their `interviewTypes` does not receive HackerRank review requests
- [ ] Verify a user with `hackerrank` in their `interviewTypes` still receives requests as before
- [ ] `pnpm verify` passes