### PR TITLE
Raise pairing session slot cap to 20

### DIFF
--- a/src/bot/__tests__/requestPairingSession.test.ts
+++ b/src/bot/__tests__/requestPairingSession.test.ts
@@ -101,7 +101,7 @@ describe('requestPairingSession', () => {
       );
     });
 
-    it('should not exceed the 7-slot cap', async () => {
+    it('should not exceed the slot cap', async () => {
       const client = buildMockWebClient();
 
       const stateValues: Record<string, any> = {
@@ -113,7 +113,7 @@ describe('requestPairingSession', () => {
           },
         },
       };
-      for (let i = 1; i <= 7; i++) {
+      for (let i = 1; i <= 20; i++) {
         stateValues[`pairing-slot-${i}-date`] = {
           [`pairing-slot-${i}-date`]: { selected_date: null },
         };
@@ -130,7 +130,7 @@ describe('requestPairingSession', () => {
         body: {
           view: {
             id: 'view-id-1',
-            private_metadata: JSON.stringify({ slotCount: 7, languages: ['Python'] }),
+            private_metadata: JSON.stringify({ slotCount: 20, languages: ['Python'] }),
             state: { values: stateValues },
           },
         } as any,

--- a/src/bot/requestPairingSession.ts
+++ b/src/bot/requestPairingSession.ts
@@ -13,7 +13,7 @@ import { pairingRequestService } from '@/services/PairingRequestService';
 import { determineExpirationTime } from '@utils/reviewExpirationUtils';
 import { PairingSession, PairingSlot, PendingPairingTeammate } from '@models/PairingSession';
 
-const MAX_SLOTS = 7;
+const MAX_SLOTS = 20;
 
 interface ModalMeta {
   slotCount: number;


### PR DESCRIPTION
## Summary
- Bumps `MAX_SLOTS` in the pairing session request modal from 7 to 20
- Slack modals are capped at 100 blocks; at ~3 blocks per slot plus headers, 20 leaves plenty of headroom

## Test plan
- [x] `pnpm verify` passes
- [ ] Manually add >7 slots in the pairing session modal in Slack