### PR TITLE
Support pairing sessions in review info shortcut

### DIFF
--- a/src/bot/__tests__/getReviewInfo.test.ts
+++ b/src/bot/__tests__/getReviewInfo.test.ts
@@ -1,13 +1,15 @@
 import { App } from '@slack/bolt';
 import { getReviewInfo } from '@bot/getReviewInfo';
 import { buildMockGlobalShortcutParam, buildMockWebClient } from '@utils/slackMocks';
-import { CandidateType, Deadline, Interaction } from '@bot/enums';
+import { CandidateType, Deadline, Interaction, InterviewFormat } from '@bot/enums';
 import { GlobalShortcutParam } from '@/slackTypes';
 import { activeReviewRepo } from '@repos/activeReviewsRepo';
 import { ActiveReview } from '@models/ActiveReview';
 import { userRepo } from '@repos/userRepo';
 import { reviewActionService } from '@/services/ReviewActionService';
 import { CreatedReviewAction } from '@/services/models/ReviewAction';
+import { pairingSessionsRepo } from '@repos/pairingSessionsRepo';
+import { PairingSession } from '@models/PairingSession';
 
 describe('getReviewInfo', () => {
   let app: App;
@@ -56,6 +58,7 @@ describe('getReviewInfo', () => {
         yardstickUrl: '',
       };
       activeReviewRepo.getReviewByThreadIdOrFail = jest.fn().mockResolvedValue(review);
+      pairingSessionsRepo.getByThreadIdOrUndefined = jest.fn().mockResolvedValue(undefined);
       userRepo.listAll = jest.fn().mockResolvedValue([]);
       reviewActionService.getActions = jest
         .fn()
@@ -65,6 +68,54 @@ describe('getReviewInfo', () => {
 
     it("should acknowledge the request so slack knows we're working on it", () => {
       expect(param.ack).toHaveBeenCalled();
+    });
+
+    describe('when the message is a pairing session', () => {
+      let pairingParam: GlobalShortcutParam;
+      const session: PairingSession = {
+        threadId: '123',
+        requestorId: 'U123',
+        candidateName: 'Dana',
+        languages: ['Python', 'Go'],
+        format: InterviewFormat.REMOTE,
+        requestedAt: new Date(1650504468906),
+        teammatesNeededCount: 2,
+        slots: [
+          {
+            id: 'slot-1',
+            date: '2026-04-20',
+            startTime: '09:00',
+            endTime: '10:00',
+            interestedTeammates: [
+              { userId: 'U456', acceptedAt: 1650504468906, formats: [InterviewFormat.REMOTE] },
+            ],
+          },
+        ],
+        pendingTeammates: [],
+        declinedTeammates: [],
+      };
+
+      beforeEach(async () => {
+        pairingParam = buildMockGlobalShortcutParam();
+        pairingParam.shortcut.message = { ts: '123' } as any;
+        pairingSessionsRepo.getByThreadIdOrUndefined = jest.fn().mockResolvedValue(session);
+        activeReviewRepo.getReviewByThreadIdOrFail = jest.fn();
+        await getReviewInfo.shortcut(pairingParam);
+      });
+
+      it('should not query the active review repo', () => {
+        expect(activeReviewRepo.getReviewByThreadIdOrFail).not.toHaveBeenCalled();
+      });
+
+      it('should open the pairing dialog', () => {
+        expect(pairingParam.client.views.open).toHaveBeenCalledWith(
+          expect.objectContaining({
+            view: expect.objectContaining({
+              title: { text: 'Pairing Session Info', type: 'plain_text' },
+            }),
+          }),
+        );
+      });
     });
 
     it('should open a view with the correct review information', () => {

--- a/src/bot/getReviewInfo.ts
+++ b/src/bot/getReviewInfo.ts
@@ -1,14 +1,16 @@
 import { GlobalShortcutParam } from '@/slackTypes';
 import { userRepo } from '@repos/userRepo';
 import { App } from '@slack/bolt';
-import { View } from '@slack/types';
+import { KnownBlock, View } from '@slack/types';
 import log from '@utils/log';
-import { ul } from '@utils/text';
-import { Interaction } from './enums';
+import { bold, formatSlot, mention, ul } from '@utils/text';
+import { InterviewFormatLabel, Interaction } from './enums';
 import { activeReviewRepo } from '@repos/activeReviewsRepo';
 import { ActiveReview } from '@models/ActiveReview';
 import { User } from '@models/User';
 import { reviewActionService } from '@/services/ReviewActionService';
+import { pairingSessionsRepo } from '@repos/pairingSessionsRepo';
+import { PairingSession } from '@models/PairingSession';
 
 export const getReviewInfo = {
   app: undefined as unknown as App,
@@ -51,6 +53,60 @@ export const getReviewInfo = {
     };
   },
 
+  pairingDialog(session: PairingSession): View {
+    const blocks: KnownBlock[] = [
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: `:mag: Pairing session for ${bold(session.candidateName)} — requested by ${mention({ id: session.requestorId })}.`,
+        },
+      },
+      { type: 'divider' },
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: ul(
+            `${bold('Format:')} ${InterviewFormatLabel.get(session.format) ?? session.format}`,
+            `${bold('Languages:')} ${session.languages.join(', ')}`,
+            `${bold('Teammates needed per slot:')} ${session.teammatesNeededCount}`,
+            `${bold('Pending responses:')} ${session.pendingTeammates.length}`,
+            `${bold('Declined:')} ${session.declinedTeammates.length}`,
+          ),
+        },
+      },
+      { type: 'divider' },
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: bold(
+            `Candidate availability (${session.slots.length} slot${session.slots.length !== 1 ? 's' : ''}):`,
+          ),
+        },
+      },
+      ...session.slots.map<KnownBlock>(slot => ({
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: ul(
+            `${formatSlot(slot.date, slot.startTime, slot.endTime)} — ${slot.interestedTeammates.length} interested${
+              slot.interestedTeammates.length > 0
+                ? `: ${slot.interestedTeammates.map(t => mention({ id: t.userId })).join(', ')}`
+                : ''
+            }`,
+          ),
+        },
+      })),
+    ];
+    return {
+      title: { text: 'Pairing Session Info', type: 'plain_text' },
+      type: 'modal',
+      blocks,
+    };
+  },
+
   missingReviewDialog(): View {
     return {
       title: {
@@ -74,8 +130,19 @@ export const getReviewInfo = {
     log.d('getReviewInfo.shortcut', `Requesting review info, user.id=${shortcut.user.id}`);
     await ack();
 
+    const threadTs = shortcut.message.ts;
+
+    const pairingSession = await pairingSessionsRepo.getByThreadIdOrUndefined(threadTs);
+    if (pairingSession) {
+      await client.views.open({
+        trigger_id: shortcut.trigger_id,
+        view: this.pairingDialog(pairingSession),
+      });
+      return;
+    }
+
     try {
-      const activeReview = await activeReviewRepo.getReviewByThreadIdOrFail(shortcut.message.ts);
+      const activeReview = await activeReviewRepo.getReviewByThreadIdOrFail(threadTs);
       const allUsers = await userRepo.listAll();
       await client.views.open({
         trigger_id: shortcut.trigger_id,
@@ -83,10 +150,7 @@ export const getReviewInfo = {
       });
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (_err: any) {
-      log.d(
-        'getReviewInfo.shortcut',
-        `Unable to find active review with ts ${shortcut.message.ts}`,
-      );
+      log.d('getReviewInfo.shortcut', `Unable to find active review with ts ${threadTs}`);
       await client.views.open({
         trigger_id: shortcut.trigger_id,
         view: this.missingReviewDialog(),


### PR DESCRIPTION
## Summary
- The "Get Review Info" message shortcut now recognizes pairing session threads in addition to HackerRank review threads
- Adds a pairing-specific dialog showing candidate, requestor, format, languages, teammates needed, pending/declined counts, and per-slot interested teammates
- Shortcut tries pairing session lookup first, then falls back to active review, then the "missing" dialog

## Test plan
- [x] `pnpm verify` passes
- [ ] Manually trigger the shortcut on a pairing session thread in Slack
- [ ] Manually trigger the shortcut on a HackerRank review thread to confirm no regression