### PR TITLE
Refill pairing teammate pool after partial acceptance

### DIFF
--- a/src/bot/__tests__/acceptPairingSlot.test.ts
+++ b/src/bot/__tests__/acceptPairingSlot.test.ts
@@ -54,7 +54,7 @@ describe('acceptPairingSlot', () => {
       .mockResolvedValue(makeInterview());
     jest
       .spyOn(PairingSessionCloserModule.pairingSessionCloser, 'closeIfComplete')
-      .mockResolvedValue(undefined);
+      .mockResolvedValue(false);
     userRepo.markNowAsLastReviewedDate = jest.fn().mockResolvedValue(undefined);
     chatService.updateDirectMessage = jest.fn().mockResolvedValue(undefined);
   });
@@ -121,6 +121,53 @@ describe('acceptPairingSlot', () => {
       await acceptPairingSlot.handleSubmitSlots(param);
 
       expect(userRepo.markNowAsLastReviewedDate).not.toHaveBeenCalled();
+    });
+
+    it('should request the next teammate if the session is still active after accept', async () => {
+      const requestNextSpy = jest
+        .spyOn(PairingRequestService.pairingRequestService, 'requestNextTeammate')
+        .mockResolvedValue(undefined);
+
+      const param = buildMockActionParam();
+      param.body.actions = [{ value: 'thread-1', action_id: 'pairing-submit-slots' } as any];
+      param.body.user = { id: 'u1', name: 'Alice' } as any;
+      param.body.message = { ts: 'msg-ts-1' } as any;
+      param.body.state = {
+        values: {
+          'pairing-dm-slots': {
+            'pairing-slot-selections': { selected_options: [{ value: 'slot-1' }] },
+          },
+        },
+      } as any;
+
+      await acceptPairingSlot.handleSubmitSlots(param);
+
+      expect(requestNextSpy).toHaveBeenCalledWith(app, expect.anything());
+    });
+
+    it('should not request the next teammate if the session was closed', async () => {
+      const requestNextSpy = jest
+        .spyOn(PairingRequestService.pairingRequestService, 'requestNextTeammate')
+        .mockResolvedValue(undefined);
+      jest
+        .spyOn(PairingSessionCloserModule.pairingSessionCloser, 'closeIfComplete')
+        .mockResolvedValue(true);
+
+      const param = buildMockActionParam();
+      param.body.actions = [{ value: 'thread-1', action_id: 'pairing-submit-slots' } as any];
+      param.body.user = { id: 'u1', name: 'Alice' } as any;
+      param.body.message = { ts: 'msg-ts-1' } as any;
+      param.body.state = {
+        values: {
+          'pairing-dm-slots': {
+            'pairing-slot-selections': { selected_options: [{ value: 'slot-1' }] },
+          },
+        },
+      } as any;
+
+      await acceptPairingSlot.handleSubmitSlots(param);
+
+      expect(requestNextSpy).not.toHaveBeenCalled();
     });
 
     it('should call closeIfComplete after recording slot selections', async () => {

--- a/src/bot/acceptPairingSlot.ts
+++ b/src/bot/acceptPairingSlot.ts
@@ -62,7 +62,7 @@ export const acceptPairingSlot = {
         const user = await userRepo.find(userId);
         const userFormats = user?.formats ?? [];
 
-        await pairingRequestService.recordSlotSelections(
+        const updatedInterview = await pairingRequestService.recordSlotSelections(
           interview,
           userId,
           selectedSlotIds,
@@ -86,7 +86,10 @@ export const acceptPairingSlot = {
           ),
         ]);
 
-        await pairingSessionCloser.closeIfComplete(acceptPairingSlot.app, threadId);
+        const closed = await pairingSessionCloser.closeIfComplete(acceptPairingSlot.app, threadId);
+        if (!closed) {
+          await pairingRequestService.requestNextTeammate(acceptPairingSlot.app, updatedInterview);
+        }
       });
     } catch (err: any) {
       await reportErrorAndContinue(acceptPairingSlot.app, 'Error handling pairing slot submit', {

--- a/src/services/PairingSessionCloser.ts
+++ b/src/services/PairingSessionCloser.ts
@@ -29,12 +29,15 @@ export function isSlotConfirmed(
 }
 
 export const pairingSessionCloser = {
-  async closeIfComplete(app: App, threadId: string): Promise<void> {
+  /**
+   * Returns true if the session was closed (or was already gone), false if it's still active.
+   */
+  async closeIfComplete(app: App, threadId: string): Promise<boolean> {
     const interview = await pairingSessionsRepo.getByThreadIdOrUndefined(threadId);
 
     if (!interview) {
       log.d('pairingSessionCloser', `Interview ${threadId} not found — likely already closed`);
-      return;
+      return true;
     }
 
     const confirmedSlots = findConfirmedSlots(interview);
@@ -58,7 +61,7 @@ export const pairingSessionCloser = {
       await Promise.all(teammates.map(t => userRepo.markNowAsLastPairingReviewedDate(t.userId)));
       await pairingSessionsRepo.remove(threadId);
       reviewLockManager.releaseLock(threadId);
-      return;
+      return true;
     }
 
     const isUnfulfilled = interview.pendingTeammates.length === 0;
@@ -71,6 +74,9 @@ export const pairingSessionCloser = {
       );
       await pairingSessionsRepo.remove(threadId);
       reviewLockManager.releaseLock(threadId);
+      return true;
     }
+
+    return false;
   },
 };


### PR DESCRIPTION
## Summary
- When a teammate accepts one or more slots but the session still needs more people, we now bring in the next person in the queue — mirroring how the decline path works
- Previously, an acceptance shrank the pending pool permanently (e.g. 5 invited → 1 partial accept → stuck at 4 pending)
- After `recordSlotSelections` + `closeIfComplete`, if the session is still active we call `requestNextTeammate` to top the pool back up

## Test plan
- [x] `pnpm verify` passes (new tests cover both the refill and the closed-session no-op)
- [ ] Manually accept a partial slot on a pairing session and confirm a new teammate is DM'd