### PR TITLE
fix: stop Slack hiding pairing chips behind "+N more"

### DIFF
--- a/src/utils/__tests__/pairingPicker.test.ts
+++ b/src/utils/__tests__/pairingPicker.test.ts
@@ -119,8 +119,34 @@ describe('meta serialization', () => {
 });
 
 describe('buildPickerBlocks', () => {
-  it('should render one actions block per day', () => {
+  it('should render one actions block per day when a day fits in one', () => {
     expect(actionBlocks(buildPickerBlocks(makeMeta()))).toHaveLength(2);
+  });
+
+  it('should never put more than five chips in an actions block', () => {
+    // Slack's client shows only the first five and hides the rest behind "+N more" — including,
+    // after a repaint, a chip the teammate had just selected.
+    const blocks = buildPickerBlocks(makeMeta([], WIDE_WEEK));
+
+    actionBlocks(blocks).forEach(b => expect(b.elements.length).toBeLessThanOrEqual(5));
+  });
+
+  it('should split a nine-chip day across two blocks rather than hiding four of them', () => {
+    const day = [{ date: '2026-04-01', startTime: '08:00', endTime: '19:00' }];
+    const blocks = actionBlocks(buildPickerBlocks(makeMeta([], day)));
+
+    expect(blocks.map(b => b.elements.length)).toEqual([5, 4]);
+    expect(blocks.flatMap(b => b.elements.map((e: any) => e.text.text))).toEqual([
+      '8 AM',
+      '9 AM',
+      '10 AM',
+      '11 AM',
+      '12 PM',
+      '1 PM',
+      '2 PM',
+      '3 PM',
+      '4 PM',
+    ]);
   });
 
   it('should render one chip per bookable session, labelled with its start time', () => {
@@ -152,12 +178,9 @@ describe('buildPickerBlocks', () => {
     expect(summaryOf(buildPickerBlocks(makeMeta([0, 99])))).toContain('1 picked');
   });
 
-  it('should stay well under Slack’s 100-block modal cap for a full week of wide windows', () => {
-    const blocks = buildPickerBlocks(makeMeta([], WIDE_WEEK));
-
-    expect(blocks.length).toBeLessThan(100);
-    // Slack rejects an actions block holding more than 25 elements.
-    actionBlocks(blocks).forEach(b => expect(b.elements.length).toBeLessThanOrEqual(25));
+  it('should stay under Slack’s 100-block modal cap for a full week of wide windows', () => {
+    // Chunking at five multiplies the block count, so this is the constraint that now binds.
+    expect(buildPickerBlocks(makeMeta([], WIDE_WEEK)).length).toBeLessThan(100);
   });
 });
 

--- a/src/utils/pairingPicker.ts
+++ b/src/utils/pairingPicker.ts
@@ -98,6 +98,22 @@ function summaryBlock(slots: PickerSlot[], selected: number[]): KnownBlock {
   return { ...textBlock(text), block_id: BlockId.PAIRING_PICKER_SUMMARY } as KnownBlock;
 }
 
+/**
+ * Slack's client renders only the first five buttons of an actions block and hides the rest behind
+ * a "+N more" overflow — whatever the API's 25-element limit says. A day of 8 AM–5 PM is seven
+ * chips, so two of them would vanish, and a repaint would swallow a selected chip right back under
+ * the fold. Chunking below the display limit keeps every time visible.
+ */
+const CHIPS_PER_ROW = 5;
+
+function chunk<T>(items: T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size));
+  }
+  return chunks;
+}
+
 export function buildPickerBlocks(meta: PickerMeta): KnownBlock[] {
   const selected = new Set(meta.selected);
 
@@ -112,10 +128,12 @@ export function buildPickerBlocks(meta: PickerMeta): KnownBlock[] {
 
   for (const [date, slots] of groupByDate(meta.slots)) {
     blocks.push(textBlock(bold(formatDate(date))));
-    blocks.push({
-      type: 'actions',
-      elements: slots.map(({ item, index }) => chip(item, index, selected.has(index))),
-    });
+    for (const row of chunk(slots, CHIPS_PER_ROW)) {
+      blocks.push({
+        type: 'actions',
+        elements: row.map(({ item, index }) => chip(item, index, selected.has(index))),
+      });
+    }
   }
 
   blocks.push({ type: 'divider' });


### PR DESCRIPTION
Follow-up to #567, caught in the test env.

## The problem

Slack's client renders only the **first five** buttons of an `actions` block and collapses the rest into a `+ N more` overflow — regardless of the API's 25-element limit, which is what the original picker was built against.

A day of 8 AM–5 PM is seven chips, so two were hidden. Worse: because every tap rebuilds the block, a chip the teammate had *just selected* slid straight back under the fold.

```
Wed, Jul 15
[ 8 AM  ]  [ 9 AM  ]
[ 10 AM ]  [ 11 AM ]
[ 12 PM ]  [ + 2 more ]   ← 1 PM and 2 PM unreachable
```

## The fix

Chunk each day into `actions` blocks of five, so every time stays visible.

Worst realistic case — seven days of 8 AM–7 PM, 63 chips — is 24 blocks, well inside Slack's 100-block modal cap. A test pins both the five-per-block ceiling and the block-count headroom.

## Note on layout

This makes every chip visible and clickable, which was the actual bug. It does **not** produce a tidy grid: Slack packs buttons two-per-row at modal width, so a nine-chip day renders as 5 (three ragged rows) then 4, with a small seam between the two blocks. Slack gives no column control over buttons.

If the raggedness proves annoying, the alternative is a `checkboxes` element per day — a clean vertical list, and because checkboxes live in an `input` block Slack tracks the state natively, which would also eliminate the per-tap round trip, the repaint lag, and the `hash` conflicts. The cost is that it looks like checkboxes rather than chips. Not doing that here without a call on the trade.

## Testing

`pnpm verify` passes — 265 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)